### PR TITLE
Fixes conflict between Prod and Staging AAT keda

### DIFF
--- a/charts/rpe-send-letter-service-container-new/values.aat.template.yaml
+++ b/charts/rpe-send-letter-service-container-new/values.aat.template.yaml
@@ -1,2 +1,7 @@
 function:
   image: ${IMAGE_NAME}
+  triggers:
+    - type: azure-blob
+      blobContainerName: "new-bulkprint"
+      accountName: "rpesendletter{{ .Values.global.environment }}"
+      blobPrefix: manifest-


### PR DESCRIPTION
### Change description ###
The Keda scaledobjects are currently monitoring the same Storage account and containers and both processing them which is not desirable. This PR will prevent the staging pods in AAT from interfering with prod-aat work


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
