### PR TITLE
Resolve CVE-2022-22970 and CVE-2022-22971

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,14 +206,14 @@ dependencyManagement {
       entry 'log4j-api'
       entry 'log4j-to-slf4j'
     }
-    // CVE-2022-22950, CVE-2022-22965
-    dependencySet(group: 'org.springframework', version: '5.3.18') {
-      entry 'spring-core'
-      entry 'spring-context'
-      entry 'spring-jcl'
+    //CVE-2022-22970, CVE-2022-22971
+    dependencySet(group: 'org.springframework', version: '5.3.20') {
       entry 'spring-aop'
       entry 'spring-beans'
+      entry 'spring-context'
+      entry 'spring-core'
       entry 'spring-expression'
+      entry 'spring-jcl'
       entry 'spring-test'
     }
   }


### PR DESCRIPTION
### Change description ###
Dependency check is failing for CVE-2022-22970 and CVE-2022-22971.
Bump spring dependencies version to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
